### PR TITLE
Fixes default for `discount_simulated_as` by changing from `none` to `not_provided`

### DIFF
--- a/v1/openapi.yaml
+++ b/v1/openapi.yaml
@@ -29660,7 +29660,7 @@ components:
         discount_simulated_as:
           description: Determines which webhooks are sent based on whether a discount is used and how it's entered. If omitted, defaults to `none`.
           type: string
-          default: none
+          default: not_provided
           enum:
             - not_provided
             - prefilled


### PR DESCRIPTION
When generating this schema with an [openapi generator for effect](https://github.com/tim-smart/openapi-gen), the referenced the default value for `discount_simulated_as` is not valid. In the schema it is set to `none` but the allowed enum has `not_provided`, `prefilled` or `entered_by_customer`. 

I fixed the issue present in my generation by changing `none` to `not_provided`